### PR TITLE
Time trace profiler output support (-ftime-trace)

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -221,6 +221,7 @@ CODEGENOPT(FineGrainedBitfieldAccesses, 1, 0) ///< Enable fine-grained bitfield 
 CODEGENOPT(StrictEnums       , 1, 0) ///< Optimize based on strict enum definition.
 CODEGENOPT(StrictVTablePointers, 1, 0) ///< Optimize based on the strict vtable pointers
 CODEGENOPT(TimePasses        , 1, 0) ///< Set when -ftime-report is enabled.
+CODEGENOPT(TimeTrace         , 1, 0) ///< Set when -ftime-trace is enabled.
 CODEGENOPT(UnrollLoops       , 1, 0) ///< Control whether loops are unrolled.
 CODEGENOPT(RerollLoops       , 1, 0) ///< Control whether loops are rerolled.
 CODEGENOPT(NoUseJumpTables   , 1, 0) ///< Set when -fno-jump-tables is enabled.

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1728,6 +1728,7 @@ def Wframe_larger_than_EQ : Joined<["-"], "Wframe-larger-than=">, Group<f_Group>
 def : Flag<["-"], "fterminated-vtables">, Alias<fapple_kext>;
 def fthreadsafe_statics : Flag<["-"], "fthreadsafe-statics">, Group<f_Group>;
 def ftime_report : Flag<["-"], "ftime-report">, Group<f_Group>, Flags<[CC1Option]>;
+def ftime_trace : Flag<["-"], "ftime-trace">, Group<f_Group>, Flags<[CC1Option]>;
 def ftlsmodel_EQ : Joined<["-"], "ftls-model=">, Group<f_Group>, Flags<[CC1Option]>;
 def ftrapv : Flag<["-"], "ftrapv">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Trap on integer overflow">;

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -257,6 +257,9 @@ public:
   /// Show timers for individual actions.
   unsigned ShowTimers : 1;
 
+  /// Output time trace profile.
+  unsigned TimeTrace : 1;
+
   /// Show the -version text.
   unsigned ShowVersion : 1;
 
@@ -438,7 +441,7 @@ public:
 public:
   FrontendOptions()
       : DisableFree(false), RelocatablePCH(false), ShowHelp(false),
-        ShowStats(false), ShowTimers(false), ShowVersion(false),
+        ShowStats(false), ShowTimers(false), TimeTrace(false), ShowVersion(false),
         FixWhatYouCan(false), FixOnlyWarnings(false), FixAndRecompile(false),
         FixToTemporaries(false), ARCMTMigrateEmitARCErrors(false),
         SkipFunctionBodies(false), UseGlobalModuleIndex(true),

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4492,6 +4492,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT_fdiagnostics_print_source_range_info);
   Args.AddLastArg(CmdArgs, options::OPT_fdiagnostics_parseable_fixits);
   Args.AddLastArg(CmdArgs, options::OPT_ftime_report);
+  Args.AddLastArg(CmdArgs, options::OPT_ftime_trace);
   Args.AddLastArg(CmdArgs, options::OPT_ftrapv);
 
   if (Arg *A = Args.getLastArg(options::OPT_ftrapv_handler_EQ)) {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1705,6 +1705,7 @@ static InputKind ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   Opts.ShowHelp = Args.hasArg(OPT_help);
   Opts.ShowStats = Args.hasArg(OPT_print_stats);
   Opts.ShowTimers = Args.hasArg(OPT_ftime_report);
+  Opts.TimeTrace = Args.hasArg(OPT_ftime_trace);
   Opts.ShowVersion = Args.hasArg(OPT_version);
   Opts.ASTMergeFiles = Args.getAllArgValues(OPT_ast_merge);
   Opts.LLVMArgs = Args.getAllArgValues(OPT_mllvm);

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -25,6 +25,7 @@
 #include "clang/Sema/ParsedTemplate.h"
 #include "clang/Sema/Scope.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Support/TimeProfiler.h"
 
 using namespace clang;
 
@@ -216,6 +217,7 @@ Parser::DeclGroupPtrTy Parser::ParseNamespace(DeclaratorContext Context,
       getCurScope(), InlineLoc, NamespaceLoc, IdentLoc, Ident,
       T.getOpenLocation(), attrs, ImplicitUsingDirectiveDecl);
 
+  llvm::TimeTraceScope timeScope("ParseNamespace", Ident != nullptr ? Ident->getName().data() : "<noname>");
   PrettyDeclStackTraceEntry CrashInfo(Actions.Context, NamespcDecl,
                                       NamespaceLoc, "parsing namespace");
 

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -19,6 +19,7 @@
 #include "clang/Sema/DeclSpec.h"
 #include "clang/Sema/ParsedTemplate.h"
 #include "clang/Sema/Scope.h"
+#include "llvm/Support/TimeProfiler.h"
 using namespace clang;
 
 /// Parse a template declaration, explicit instantiation, or
@@ -231,6 +232,8 @@ Decl *Parser::ParseSingleDeclarationAfterTemplate(
       ConsumeToken();
     return nullptr;
   }
+
+  llvm::TimeTraceScope timeScope("Template", DeclaratorInfo.getIdentifier() != nullptr ? DeclaratorInfo.getIdentifier()->getName().data() : "<unknown>");
 
   LateParsedAttrList LateParsedAttrs(true);
   if (DeclaratorInfo.isFunctionDeclarator())

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -26,6 +26,7 @@
 #include "clang/Sema/Template.h"
 #include "clang/Sema/TemplateDeduction.h"
 #include "clang/Sema/TemplateInstCallback.h"
+#include "llvm/Support/TimeProfiler.h"
 
 using namespace clang;
 using namespace sema;
@@ -2009,6 +2010,9 @@ Sema::InstantiateClass(SourceLocation PointOfInstantiation,
                                 Instantiation->getInstantiatedFromMemberClass(),
                                      Pattern, PatternDef, TSK, Complain))
     return true;
+
+  llvm::TimeTraceScope timeScope("InstantiateClass", Instantiation->getNameAsString().c_str());
+
   Pattern = PatternDef;
 
   // Record the point of instantiation.

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -24,6 +24,7 @@
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Template.h"
 #include "clang/Sema/TemplateInstCallback.h"
+#include "llvm/Support/TimeProfiler.h"
 
 using namespace clang;
 
@@ -3876,6 +3877,8 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
         std::make_pair(Function, PointOfInstantiation));
     return;
   }
+
+  llvm::TimeTraceScope timeScope("InstantiateFunction", Function->getNameAsString().data());
 
   // If we're performing recursive template instantiation, create our own
   // queue of pending implicit instantiations that we will instantiate later,

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -35,8 +35,10 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdio>
@@ -195,6 +197,10 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
   bool Success = CompilerInvocation::CreateFromArgs(
       Clang->getInvocation(), Argv.begin(), Argv.end(), Diags);
 
+  if (Clang->getFrontendOpts().TimeTrace) {
+    llvm::TimeTraceProfilerInitialize();
+  }
+
   // Infer the builtin include path if unspecified.
   if (Clang->getHeaderSearchOpts().UseBuiltinIncludes &&
       Clang->getHeaderSearchOpts().ResourceDir.empty())
@@ -221,6 +227,21 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
   // If any timers were active but haven't been destroyed yet, print their
   // results now.  This happens in -disable-free mode.
   llvm::TimerGroup::printAll(llvm::errs());
+
+  if (llvm::TimeTraceProfilerEnabled()) {
+    SmallString<128> Path(Clang->getFrontendOpts().OutputFile);
+    llvm::sys::path::replace_extension(Path, "json");
+    auto profilerOutput = Clang->createOutputFile(
+        Path.str(),
+        /*Binary=*/false,
+        /*RemoveFileOnSignal=*/false,
+        "",
+        /*Extension=*/"json",
+        /*useTemporary=*/false);    
+
+    llvm::TimeTraceProfilerWrite(profilerOutput);
+    llvm::TimeTraceProfilerCleanup();
+  }
 
   // Our error handler depends on the Diagnostics object, which we're
   // potentially about to delete. Uninstall the handler now so that any

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -222,7 +222,10 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
     return 1;
 
   // Execute the frontend actions.
-  Success = ExecuteCompilerInvocation(Clang.get());
+  {
+    llvm::TimeTraceScope scope("ExecuteCompiler", "");
+    Success = ExecuteCompilerInvocation(Clang.get());
+  }
 
   // If any timers were active but haven't been destroyed yet, print their
   // results now.  This happens in -disable-free mode.

--- a/llvm/include/llvm/Support/TimeProfiler.h
+++ b/llvm/include/llvm/Support/TimeProfiler.h
@@ -17,14 +17,38 @@ namespace llvm {
 struct TimeTraceProfiler;
 extern TimeTraceProfiler *TimeTraceProfilerInstance;
 
-
+/// Initialize the time trace profiler.
+/// This sets up the global \p TimeTraceProfilerInstance
+/// variable to be the profiler instance.
 void TimeTraceProfilerInitialize();
-void TimeTraceProfilerCleanup();
-void TimeTraceProfilerWrite(std::unique_ptr<raw_pwrite_stream>& OS);
-void TimeTraceProfilerBegin(const char *name, const char *detail);
-void TimeTraceProfilerEnd();
-inline bool TimeTraceProfilerEnabled() { return TimeTraceProfilerInstance != nullptr; }
 
+/// Cleanup the time trace profiler, if it was initialized.
+void TimeTraceProfilerCleanup();
+
+/// Is the time trace profiler enabled, i.e. initialized?
+inline bool TimeTraceProfilerEnabled() {
+  return TimeTraceProfilerInstance != nullptr;
+}
+
+/// Write profiling data to output file.
+/// Data produced is JSON, in Chrome "Trace Event" format, see
+/// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+void TimeTraceProfilerWrite(std::unique_ptr<raw_pwrite_stream> &OS);
+
+/// Manually begin a time section, with the given \p name and \p detail.
+/// Profiler copies the string data, so the pointers can be given into
+/// temporaries. Time sections can be hierarchical; every Begin must have a
+/// matching End pair but they can nest.
+void TimeTraceProfilerBegin(const char *name, const char *detail);
+
+/// Manually end the last time section.
+void TimeTraceProfilerEnd();
+
+/// The TimeTraceScope is a helper class to call the begin and end functions.
+/// of the time trace profiler.  When the object is constructed, it
+/// begins the section; and wen it is destroyed, it stops
+/// it.  If the time profiler is not initialized, the overhead
+/// is a single branch.
 struct TimeTraceScope {
   TimeTraceScope(const char *name, const char *detail) {
     if (TimeTraceProfilerInstance != nullptr)
@@ -35,8 +59,6 @@ struct TimeTraceScope {
       TimeTraceProfilerEnd();
   }
 };
-
-
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Support/TimeProfiler.h
+++ b/llvm/include/llvm/Support/TimeProfiler.h
@@ -1,0 +1,43 @@
+//===- llvm/Support/TimeProfiler.h - Hierarchical Time Profiler -*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_TIME_PROFILER_H
+#define LLVM_SUPPORT_TIME_PROFILER_H
+
+#include "llvm/Support/raw_ostream.h"
+
+namespace llvm {
+
+struct TimeTraceProfiler;
+extern TimeTraceProfiler *TimeTraceProfilerInstance;
+
+
+void TimeTraceProfilerInitialize();
+void TimeTraceProfilerCleanup();
+void TimeTraceProfilerWrite(std::unique_ptr<raw_pwrite_stream>& OS);
+void TimeTraceProfilerBegin(const char *name, const char *detail);
+void TimeTraceProfilerEnd();
+inline bool TimeTraceProfilerEnabled() { return TimeTraceProfilerInstance != nullptr; }
+
+struct TimeTraceScope {
+  TimeTraceScope(const char *name, const char *detail) {
+    if (TimeTraceProfilerInstance != nullptr)
+      TimeTraceProfilerBegin(name, detail);
+  }
+  ~TimeTraceScope() {
+    if (TimeTraceProfilerInstance != nullptr)
+      TimeTraceProfilerEnd();
+  }
+};
+
+
+
+} // end namespace llvm
+
+#endif

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -130,6 +130,7 @@ add_llvm_library(LLVMSupport
   TarWriter.cpp
   TargetParser.cpp
   ThreadPool.cpp
+  TimeProfiler.cpp
   Timer.cpp
   ToolOutputFile.cpp
   TrigramIndex.cpp

--- a/llvm/lib/Support/TimeProfiler.cpp
+++ b/llvm/lib/Support/TimeProfiler.cpp
@@ -21,9 +21,11 @@
 using namespace std::chrono;
 
 namespace llvm {
+
 TimeTraceProfiler *TimeTraceProfilerInstance = nullptr;
 
-static void EscapeString(std::string &os, const char *src) {
+static std::string EscapeString(const char *src) {
+  std::string os;
   while (*src) {
     char c = *src;
     switch (c) {
@@ -44,6 +46,7 @@ static void EscapeString(std::string &os, const char *src) {
     }
     ++src;
   }
+  return os;
 }
 
 struct Entry {
@@ -55,27 +58,29 @@ struct Entry {
 
 struct TimeTraceProfiler {
   TimeTraceProfiler() {
-    Stack.reserve(16);
+    Stack.reserve(8);
     Entries.reserve(128);
     StartTime = steady_clock::now();
   }
-  ~TimeTraceProfiler() {}
 
   void Begin(const std::string &name, const std::string &detail) {
     Entry e = {steady_clock::now(), {}, name, detail};
     Stack.emplace_back(e);
   }
+
   void End() {
     assert(!Stack.empty() && "Must call Begin first");
     auto &e = Stack.back();
     e.Duration = steady_clock::now() - e.Start;
+    // skip sections under 3ms in length
     if (duration_cast<milliseconds>(e.Duration).count() > 3)
       Entries.emplace_back(e);
     Stack.pop_back();
   }
-  void Write(std::unique_ptr<raw_pwrite_stream>& os) {
-    while (!Stack.empty())
-      End();
+
+  void Write(std::unique_ptr<raw_pwrite_stream> &os) {
+    assert(Stack.empty() &&
+           "All profiler sections should be ended when calling Write");
 
     *os << "{ \"traceEvents\": [\n";
     *os << "{ \"cat\":\"\", \"pid\":1, \"tid\":0, \"ts\":0, \"ph\":\"M\", "
@@ -83,12 +88,10 @@ struct TimeTraceProfiler {
     for (const auto &e : Entries) {
       auto startUs = duration_cast<microseconds>(e.Start - StartTime).count();
       auto durUs = duration_cast<microseconds>(e.Duration).count();
-      std::string name, detail;
-      EscapeString(name, e.Name.c_str());
-      EscapeString(detail, e.Detail.c_str());
       *os << ", { \"pid\":1, \"tid\":0, \"ph\":\"X\", \"ts\":" << startUs
-          << ", \"dur\":" << durUs << ", \"name\":\"" << name
-          << "\", \"args\":{ \"detail\":\"" << detail << "\"} }\n";
+          << ", \"dur\":" << durUs << ", \"name\":\""
+          << EscapeString(e.Name.c_str()) << "\", \"args\":{ \"detail\":\""
+          << EscapeString(e.Detail.c_str()) << "\"} }\n";
     }
     *os << "] }\n";
   }
@@ -109,7 +112,7 @@ void TimeTraceProfilerCleanup() {
   TimeTraceProfilerInstance = nullptr;
 }
 
-void TimeTraceProfilerWrite(std::unique_ptr<raw_pwrite_stream>& OS) {
+void TimeTraceProfilerWrite(std::unique_ptr<raw_pwrite_stream> &OS) {
   assert(TimeTraceProfilerInstance != nullptr &&
          "Profiler object can't be null");
   TimeTraceProfilerInstance->Write(OS);

--- a/llvm/lib/Support/TimeProfiler.cpp
+++ b/llvm/lib/Support/TimeProfiler.cpp
@@ -69,7 +69,7 @@ struct TimeTraceProfiler {
     assert(!Stack.empty() && "Must call Begin first");
     auto &e = Stack.back();
     e.Duration = steady_clock::now() - e.Start;
-    if (duration_cast<milliseconds>(e.Duration).count() > 10)
+    if (duration_cast<milliseconds>(e.Duration).count() > 3)
       Entries.emplace_back(e);
     Stack.pop_back();
   }

--- a/llvm/lib/Support/TimeProfiler.cpp
+++ b/llvm/lib/Support/TimeProfiler.cpp
@@ -1,0 +1,128 @@
+//===-- TimeProfiler.cpp - Hierarchical Time Profiler ---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file Hierarchical time profiler implementation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/FileSystem.h"
+#include <cassert>
+#include <chrono>
+#include <string>
+#include <vector>
+
+using namespace std::chrono;
+
+namespace llvm {
+TimeTraceProfiler *TimeTraceProfilerInstance = nullptr;
+
+static void EscapeString(std::string &os, const char *src) {
+  while (*src) {
+    char c = *src;
+    switch (c) {
+    case '"':
+    case '\\':
+    case '\b':
+    case '\f':
+    case '\n':
+    case '\r':
+    case '\t':
+      os += '\\';
+      os += c;
+      break;
+    default:
+      if (c >= 32 && c < 126) {
+        os += c;
+      }
+    }
+    ++src;
+  }
+}
+
+struct Entry {
+  time_point<steady_clock> Start;
+  duration<steady_clock::rep, steady_clock::period> Duration;
+  std::string Name;
+  std::string Detail;
+};
+
+struct TimeTraceProfiler {
+  TimeTraceProfiler() {
+    Stack.reserve(16);
+    Entries.reserve(128);
+    StartTime = steady_clock::now();
+  }
+  ~TimeTraceProfiler() {}
+
+  void Begin(const std::string &name, const std::string &detail) {
+    Entry e = {steady_clock::now(), {}, name, detail};
+    Stack.emplace_back(e);
+  }
+  void End() {
+    assert(!Stack.empty() && "Must call Begin first");
+    auto &e = Stack.back();
+    e.Duration = steady_clock::now() - e.Start;
+    if (duration_cast<milliseconds>(e.Duration).count() > 10)
+      Entries.emplace_back(e);
+    Stack.pop_back();
+  }
+  void Write(std::unique_ptr<raw_pwrite_stream>& os) {
+    while (!Stack.empty())
+      End();
+
+    *os << "{ \"traceEvents\": [\n";
+    *os << "{ \"cat\":\"\", \"pid\":1, \"tid\":0, \"ts\":0, \"ph\":\"M\", "
+           "\"name\":\"process_name\", \"args\":{ \"name\":\"clang\" } }\n";
+    for (const auto &e : Entries) {
+      auto startUs = duration_cast<microseconds>(e.Start - StartTime).count();
+      auto durUs = duration_cast<microseconds>(e.Duration).count();
+      std::string name, detail;
+      EscapeString(name, e.Name.c_str());
+      EscapeString(detail, e.Detail.c_str());
+      *os << ", { \"pid\":1, \"tid\":0, \"ph\":\"X\", \"ts\":" << startUs
+          << ", \"dur\":" << durUs << ", \"name\":\"" << name
+          << "\", \"args\":{ \"detail\":\"" << detail << "\"} }\n";
+    }
+    *os << "] }\n";
+  }
+
+  std::vector<Entry> Stack;
+  std::vector<Entry> Entries;
+  time_point<steady_clock> StartTime;
+};
+
+void TimeTraceProfilerInitialize() {
+  assert(TimeTraceProfilerInstance == nullptr &&
+         "Profiler should not be initialized");
+  TimeTraceProfilerInstance = new TimeTraceProfiler();
+}
+
+void TimeTraceProfilerCleanup() {
+  delete TimeTraceProfilerInstance;
+  TimeTraceProfilerInstance = nullptr;
+}
+
+void TimeTraceProfilerWrite(std::unique_ptr<raw_pwrite_stream>& OS) {
+  assert(TimeTraceProfilerInstance != nullptr &&
+         "Profiler object can't be null");
+  TimeTraceProfilerInstance->Write(OS);
+}
+
+void TimeTraceProfilerBegin(const char *name, const char *detail) {
+  if (TimeTraceProfilerInstance != nullptr)
+    TimeTraceProfilerInstance->Begin(name, detail);
+}
+
+void TimeTraceProfilerEnd() {
+  if (TimeTraceProfilerInitialize != nullptr)
+    TimeTraceProfilerInstance->End();
+}
+
+} // namespace llvm


### PR DESCRIPTION
Adds `-ftime-trace` option to clang that produces Chrome `chrome://tracing` compatible JSON profiling output dumps.

Here's one from Catch2 test examples, showing that even in debug build the backend spends up quite some time:
![clang-trace-catch](https://user-images.githubusercontent.com/348087/51034955-21aea880-15b1-11e9-94d2-c2907f2310a3.png)

Here's one that found really bad recursive macros case in our codebase, that made Clang spend ~8s just at including a seemingly simple file:
![clang-trace-format-slow](https://user-images.githubusercontent.com/348087/51034991-44d95800-15b1-11e9-9be6-284db44d6395.png)

Here's one from range-v3 pythagorean triples via list comprehensions example:
![clang-trace-rangesv3](https://user-images.githubusercontent.com/348087/51035021-57ec2800-15b1-11e9-98a4-f1f9bd6d506f.png)
